### PR TITLE
Add Streamlit EDA app base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # TestStream
+
+This repository contains a basic Streamlit application for performing exploratory data analysis (EDA) on CSV datasets.
+
+## Setup
+
+Install the required dependencies and run the Streamlit app:
+
+```bash
+pip install streamlit pandas matplotlib
+streamlit run streamlit_app.py
+```
+
+Upload a CSV file to view the data preview, summary statistics, and a histogram for numeric columns.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+matplotlib

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,27 @@
+import streamlit as st
+import pandas as pd
+import matplotlib.pyplot as plt
+
+st.title('Exploratory Data Analysis App')
+
+uploaded_file = st.file_uploader('Upload a CSV file', type='csv')
+if uploaded_file is not None:
+    df = pd.read_csv(uploaded_file)
+    st.subheader('Data Preview')
+    st.write(df.head())
+
+    st.subheader('Summary Statistics')
+    st.write(df.describe())
+
+    columns = df.select_dtypes(include=['float', 'int']).columns
+    if len(columns) > 0:
+        column = st.selectbox('Select column for histogram', columns)
+        fig, ax = plt.subplots()
+        df[column].hist(ax=ax, bins=30)
+        ax.set_xlabel(column)
+        ax.set_ylabel('Frequency')
+        st.pyplot(fig)
+    else:
+        st.write('No numeric columns available for histogram.')
+else:
+    st.write('Please upload a CSV file to begin.')


### PR DESCRIPTION
## Summary
- add a simple Streamlit app for EDA on CSV files
- document setup instructions
- specify Python dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e324556ac832b90ec7836b2b409f3